### PR TITLE
Add support for application/csv MIME type

### DIFF
--- a/app/models/spree/product_import.rb
+++ b/app/models/spree/product_import.rb
@@ -15,7 +15,7 @@ module Spree
 
     validates_attachment_presence :data_file
     # Content type of csv vary in different browsers.
-    validates_attachment :data_file, presence: true, content_type: { content_type: ['text/csv', 'text/plain', 'text/comma-separated-values', 'application/octet-stream', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'] }
+    validates_attachment :data_file, presence: true, content_type: { content_type: ['text/csv', 'text/plain', 'text/comma-separated-values', 'application/octet-stream', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/csv'] }
 
     after_destroy :destroy_products
 

--- a/config/initializers/paper_clip.rb
+++ b/config/initializers/paper_clip.rb
@@ -1,6 +1,6 @@
 require 'paperclip/railtie'
 Paperclip::Railtie.insert
-Paperclip.options[:content_type_mappings] = { csv: 'text/plain' }
+Paperclip.options[:content_type_mappings] = { csv: %w[text/plain application/csv] }
 
 Paperclip.interpolates :timestamp do |attachment, _style|
   attachment.instance_read(:updated_at).strftime('%Y%m%d%H%M%S')


### PR DESCRIPTION
Starting with MacOS Big Sur (11.x), the filesystem assigns the "application/csv"
MIME type to .csv files. Attempting to import products from a csv with this
MIME type will cause multiple validation errors. This happens for two reasons:

1. Paperclip is not configured to associate the .csv filetype with the application/csv
   MIME type;
2. The ProductImport validations do not include application/csv as a valid type

Adding application/csv to these two places fixes the issue and make it possible
to import csv files with the application/csv MIME type.